### PR TITLE
Upgrade Akka to 2.4.2-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,19 +7,18 @@ version := "1.0"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= {
-  val akkaVersion = "2.4.1"
-  val akkaStreamAndHttpVersion = "2.0"
+  val akkaVersion = "2.4.2-RC1"
   val slickVersion = "3.1.1"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-    "com.typesafe.akka" %% "akka-stream-experimental" % akkaStreamAndHttpVersion,
-    "io.reactivex" %% "rxscala" % "0.25.0",
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "io.reactivex" %% "rxscala" % "0.26.0",
     "io.reactivex" % "rxjava-reactive-streams" % "1.0.1",
     "com.typesafe.slick" %% "slick" % slickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
     "org.postgresql" % "postgresql" % "9.4-1206-jdbc42",
-    "com.typesafe.akka" %% "akka-http-spray-json-experimental" % akkaStreamAndHttpVersion,
-    "com.typesafe.akka" %% "akka-stream-testkit-experimental" % akkaStreamAndHttpVersion % Test,
+    "com.typesafe.akka" %% "akka-http-spray-json-experimental" % akkaVersion,
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
     "org.scalatest" %% "scalatest" % "2.2.4" % Test
   )


### PR DESCRIPTION
Seems you could upgrade Akka, and avoid having "-experimental" in a few of the Akka packages.

One tangible benefit is quieting this library eviction warning when SBT starts compiling.

```
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.typesafe.akka:akka-actor_2.11:2.3.12 -> 2.4.1
[warn] Run 'evicted' to see detailed eviction warnings
```
