### PR TITLE
Run against H2 database

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,10 +16,10 @@ libraryDependencies ++= {
     "io.reactivex" % "rxjava-reactive-streams" % "1.0.1",
     "com.typesafe.slick" %% "slick" % slickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-    "org.postgresql" % "postgresql" % "9.4-1206-jdbc42",
     "com.typesafe.akka" %% "akka-http-spray-json-experimental" % akkaVersion,
     "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
+    "com.h2database" % "h2" % "1.4.191",
     "org.scalatest" %% "scalatest" % "2.2.4" % Test
   )
 }
@@ -27,6 +27,8 @@ libraryDependencies ++= {
 fork in Test := true
 
 parallelExecution := false
+
+testForkedParallel in Test := false
 
 licenses +=("Apache-2.0", url("http://opensource.org/licenses/apache2.0.php"))
 

--- a/src/main/scala/com/github/dnvriend/CoffeeRepository.scala
+++ b/src/main/scala/com/github/dnvriend/CoffeeRepository.scala
@@ -17,8 +17,8 @@
 package com.github.dnvriend
 
 import slick.backend.DatabasePublisher
-import slick.driver.PostgresDriver
-import slick.driver.PostgresDriver.api._
+import slick.dbio.DBIO
+import slick.driver.H2Driver.api._
 import slick.jdbc.GetResult
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -57,7 +57,7 @@ object CoffeeRepository {
   val coffees: TableQuery[CoffeeRepository.Coffees] = TableQuery[Coffees]
 
   def dropCreateSchema(implicit db: Database, ec: ExecutionContext): Future[Unit] = {
-    val schema: PostgresDriver.DDL = suppliers.schema ++ coffees.schema
+    val schema = suppliers.schema ++ coffees.schema
     db.run(schema.create)
       .recoverWith {
         case t: Throwable ⇒

--- a/src/main/scala/com/github/dnvriend/DbExtension.scala
+++ b/src/main/scala/com/github/dnvriend/DbExtension.scala
@@ -26,5 +26,5 @@ object DbExtension extends ExtensionId[DbExtensionImpl] with ExtensionIdProvider
 }
 
 class DbExtensionImpl()(implicit val system: ExtendedActorSystem) extends JdbcBackend with Extension {
-  implicit val db: Database = Database.forConfig("mydb")
+  implicit val db: Database = Database.forConfig("h2")
 }

--- a/src/main/scala/com/github/dnvriend/PersonRepository.scala
+++ b/src/main/scala/com/github/dnvriend/PersonRepository.scala
@@ -20,8 +20,8 @@ import java.sql.{ Date, Timestamp }
 import java.text.SimpleDateFormat
 import java.util.UUID
 
-import slick.driver.PostgresDriver
-import slick.driver.PostgresDriver.api._
+import slick.dbio.DBIO
+import slick.driver.H2Driver.api._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -47,7 +47,7 @@ object PersonRepository {
   val persons: TableQuery[PersonRepository.Persons] = TableQuery[Persons]
 
   def dropCreateSchema(implicit db: Database, ec: ExecutionContext): Future[Unit] = {
-    val schema: PostgresDriver.SchemaDescription = persons.schema
+    val schema = persons.schema
     db.run(schema.create)
       .recoverWith {
         case t: Throwable ⇒

--- a/src/main/scala/com/github/dnvriend/UsersRepository.scala
+++ b/src/main/scala/com/github/dnvriend/UsersRepository.scala
@@ -16,8 +16,8 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver
-import slick.driver.PostgresDriver.api._
+import slick.dbio.DBIO
+import slick.driver.H2Driver.api._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -34,7 +34,7 @@ object UsersRepository {
   val users: TableQuery[UsersRepository.Users] = TableQuery[Users]
 
   def dropCreateSchema(implicit db: Database, ec: ExecutionContext): Future[Unit] = {
-    val schema: PostgresDriver.SchemaDescription = users.schema
+    val schema = users.schema
     db.run(schema.create)
       .recoverWith {
         case t: Throwable ⇒

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -39,6 +39,12 @@ postgres {
   port = ${?POSTGRES_PORT}
 }
 
+h2 {
+    url = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+    connectionPool = disabled
+    driver = "slick.driver.H2Driver$"
+}
+
 mydb = {
   dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
   properties = {

--- a/src/test/scala/com/github/dnvriend/ApplicativeJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/ApplicativeJoinTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class ApplicativeJoinTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/ApplicativeJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/ApplicativeJoinTest.scala
@@ -39,7 +39,7 @@ class ApplicativeJoinTest extends TestSpec {
       (c, s) ← coffees join suppliers
     } yield (c.name, s.name)
 
-    db.run(crossJoin.result).futureValue shouldBe List(
+    db.run(crossJoin.result).futureValue should contain theSameElementsAs List(
       ("Colombian", "Acme, Inc."),
       ("Colombian", "Superior Coffee"),
       ("Colombian", "The High Ground"),
@@ -63,7 +63,7 @@ class ApplicativeJoinTest extends TestSpec {
       (c, s) ← coffees join suppliers on (_.supID === _.id)
     } yield (c.name, s.name)
 
-    db.run(innerJoin.result).futureValue shouldBe List(
+    db.run(innerJoin.result).futureValue should contain theSameElementsAs List(
       ("Colombian", "Acme, Inc."),
       ("French_Roast", "Superior Coffee"),
       ("Espresso", "The High Ground"),
@@ -84,7 +84,7 @@ class ApplicativeJoinTest extends TestSpec {
       (c, s) ← coffees joinLeft suppliers on (_.supID === _.id)
     } yield (c.name, s.map(_.name))
 
-    db.run(leftOuterJoin.result).futureValue shouldBe List(
+    db.run(leftOuterJoin.result).futureValue should contain theSameElementsAs List(
       ("Colombian", Some("Acme, Inc.")),
       ("French_Roast", Some("Superior Coffee")),
       ("Espresso", Some("The High Ground")),
@@ -98,7 +98,7 @@ class ApplicativeJoinTest extends TestSpec {
       (c, s) ← coffees joinRight suppliers on (_.supID === _.id)
     } yield (c.map(_.name), s.name)
 
-    db.run(rightOuterJoin.result).futureValue shouldBe List(
+    db.run(rightOuterJoin.result).futureValue should contain theSameElementsAs List(
       (Some("Colombian"), "Acme, Inc."),
       (Some("French_Roast"), "Superior Coffee"),
       (Some("Espresso"), "The High Ground"),
@@ -112,7 +112,7 @@ class ApplicativeJoinTest extends TestSpec {
       (c, s) ← coffees joinFull suppliers on (_.supID === _.id)
     } yield (c.map(_.name), s.map(_.name))
 
-    db.run(fullOuterJoin.result).futureValue shouldBe List(
+    db.run(fullOuterJoin.result).futureValue should contain theSameElementsAs List(
       (Some("Colombian"), Some("Acme, Inc.")),
       (Some("French_Roast"), Some("Superior Coffee")),
       (Some("Espresso"), Some("The High Ground")),

--- a/src/test/scala/com/github/dnvriend/DateTimeTest.scala
+++ b/src/test/scala/com/github/dnvriend/DateTimeTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class DateTimeTest extends TestSpec {
   import PersonRepository._

--- a/src/test/scala/com/github/dnvriend/DeleteTest.scala
+++ b/src/test/scala/com/github/dnvriend/DeleteTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class DeleteTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/GroupingTest.scala
+++ b/src/test/scala/com/github/dnvriend/GroupingTest.scala
@@ -42,7 +42,7 @@ class GroupingTest extends TestSpec {
         (supID, css.length, css.map(_._1.price).avg)
     }
 
-    db.run(q2.result).futureValue shouldBe List(
+    db.run(q2.result).futureValue should contain theSameElementsAs List(
       (101, 2, Some(9.49)),
       (49, 2, Some(9.49)),
       (150, 1, Some(11.99))

--- a/src/test/scala/com/github/dnvriend/GroupingTest.scala
+++ b/src/test/scala/com/github/dnvriend/GroupingTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class GroupingTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/InsertTest.scala
+++ b/src/test/scala/com/github/dnvriend/InsertTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class InsertTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/MonadicJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/MonadicJoinTest.scala
@@ -44,7 +44,7 @@ class MonadicJoinTest extends TestSpec {
       s ← suppliers
     } yield (c.name, s.name)
 
-    db.run(monadicCrossJoin.result).futureValue shouldBe List(
+    db.run(monadicCrossJoin.result).futureValue should contain theSameElementsAs List(
       ("Colombian", "Acme, Inc."),
       ("Colombian", "Superior Coffee"),
       ("Colombian", "The High Ground"),
@@ -70,7 +70,7 @@ class MonadicJoinTest extends TestSpec {
       s ← suppliers if c.supID === s.id
     } yield (c.name, s.name)
 
-    db.run(monadicInnerJoin.result).futureValue shouldBe List(
+    db.run(monadicInnerJoin.result).futureValue should contain theSameElementsAs List(
       ("Colombian", "Acme, Inc."),
       ("French_Roast", "Superior Coffee"),
       ("Espresso", "The High Ground"),

--- a/src/test/scala/com/github/dnvriend/MonadicJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/MonadicJoinTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class MonadicJoinTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/PlainSqlTest.scala
+++ b/src/test/scala/com/github/dnvriend/PlainSqlTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class PlainSqlTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/QueryCoffeesTest.scala
+++ b/src/test/scala/com/github/dnvriend/QueryCoffeesTest.scala
@@ -132,7 +132,7 @@ class QueryCoffeesTest extends TestSpec {
 
   it should "get the name field only" in {
     // SELECT NAME FROM COFFEES
-    db.run(coffees.map(_.name).result).futureValue shouldBe
+    db.run(coffees.map(_.name).result).futureValue should contain theSameElementsAs
       List("Colombian", "French_Roast", "Espresso", "Colombian_Decaf", "French_Roast_Decaf")
   }
 

--- a/src/test/scala/com/github/dnvriend/QueryCoffeesTest.scala
+++ b/src/test/scala/com/github/dnvriend/QueryCoffeesTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class QueryCoffeesTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/TestSpec.scala
+++ b/src/test/scala/com/github/dnvriend/TestSpec.scala
@@ -23,12 +23,13 @@ import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import slick.jdbc.JdbcBackend
 import spray.json.DefaultJsonProtocol
+import slick.driver.H2Driver.api._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
-trait TestSpec extends FlatSpec with Matchers with ScalaFutures with OptionValues with BeforeAndAfterEach with BeforeAndAfterAll with DefaultJsonProtocol with GivenWhenThen {
+trait TestSpec extends FlatSpec with Matchers with ScalaFutures with OptionValues with BeforeAndAfterEach with BeforeAndAfterAll with DefaultJsonProtocol with GivenWhenThen /* with ParallelTestExecution */ {
   implicit val system: ActorSystem = ActorSystem()
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val mat: Materializer = ActorMaterializer()

--- a/src/test/scala/com/github/dnvriend/UnionTest.scala
+++ b/src/test/scala/com/github/dnvriend/UnionTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class UnionTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/UpdateTest.scala
+++ b/src/test/scala/com/github/dnvriend/UpdateTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class UpdateTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/ZipJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/ZipJoinTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.dnvriend
 
-import slick.driver.PostgresDriver.api._
+import slick.driver.H2Driver.api._
 
 class ZipJoinTest extends TestSpec {
 

--- a/src/test/scala/com/github/dnvriend/ZipJoinTest.scala
+++ b/src/test/scala/com/github/dnvriend/ZipJoinTest.scala
@@ -35,8 +35,8 @@ class ZipJoinTest extends TestSpec {
     } yield (c.name, s.name)
 
     db.run(zipJoinQuery.result).futureValue shouldBe List(
-      ("Colombian", "Acme, Inc."),
-      ("French_Roast", "Superior Coffee"),
+      ("Colombian", "Superior Coffee"),
+      ("Colombian_Decaf", "Acme, Inc."),
       ("Espresso", "The High Ground")
     )
   }
@@ -47,8 +47,8 @@ class ZipJoinTest extends TestSpec {
     } yield res
 
     db.run(zipWithJoin.result).futureValue shouldBe List(
-      ("Colombian", "Acme, Inc."),
-      ("French_Roast", "Superior Coffee"),
+      ("Colombian", "Superior Coffee"),
+      ("Colombian_Decaf", "Acme, Inc."),
       ("Espresso", "The High Ground")
     )
   }
@@ -67,9 +67,9 @@ class ZipJoinTest extends TestSpec {
 
     db.run(zipWithIndexJoin.result).futureValue shouldBe List(
       ("Colombian", 0),
-      ("French_Roast", 1),
+      ("Colombian_Decaf", 1),
       ("Espresso", 2),
-      ("Colombian_Decaf", 3),
+      ("French_Roast", 3),
       ("French_Roast_Decaf", 4)
     )
   }


### PR DESCRIPTION
I was curious if the tests could be run against the H2 database instead of Postgres.  It was easy enough to make it work, and required minimal changes.  So, that's good.

However, there were some curious differences with H2.  Some were unsurprising, but others more so.  For example, H2 might return a different order of rows — when there is no `sortBy` provided (`ORDER BY`) — than Postgres.  That seems reasonable and expected for a database to do, and fortunately it orders them a consistent and repeatable manner.

Likewise, the [ROWNUM()](http://www.h2database.com/html/functions.html#rownum) function in H2 doesn't seem to behave like Postgres, although it is consistent and repeatable.  `ROWNUM()` is technically not in ANSI/ISO SQL and the Slick manual hints at such a problem:

> A particular kind of zip join is provided by `zipWithIndex`. It zips a query result with an infinite sequence starting at 0. Such a sequence cannot be represented by an SQL database and Slick does not currently support it, either. The resulting zipped query, however, can be represented in SQL with the use of a row _number_ function, so `zipWithIndex` is supported as a primitive operator:

Here is the result of running the `ZipJoinTest.zipWithIndex` test with debug enabled that shows the problem with `ROWNUM()`:

```
> testOnly com.github.dnvriend.ZipJoinTest -- -z zipWithIndex
DEBUG s.backend.DatabaseComponent.action - #1: result [select "COF_NAME", rownum - 1 from "COFFEES"]
DEBUG slick.jdbc.JdbcBackend.statement - Preparing statement: select "COF_NAME", rownum - 1 from "COFFEES"
DEBUG slick.jdbc.JdbcBackend.statement - Preparing statement: select "COF_NAME", rownum - 1 from "COFFEES"
DEBUG slick.jdbc.StatementInvoker.result - /--------------------+--------------\
DEBUG slick.jdbc.StatementInvoker.result - | 1                  | 2            |
DEBUG slick.jdbc.StatementInvoker.result - | COF_NAME           | ROWNUM() - 1 |
DEBUG slick.jdbc.StatementInvoker.result - |--------------------+--------------|
DEBUG slick.jdbc.StatementInvoker.result - | Colombian          | 0            |
DEBUG slick.jdbc.StatementInvoker.result - | Colombian_Decaf    | 1            |
DEBUG slick.jdbc.StatementInvoker.result - | Espresso           | 2            |
DEBUG slick.jdbc.StatementInvoker.result - | French_Roast       | 3            |
DEBUG slick.jdbc.StatementInvoker.result - | French_Roast_Decaf | 4            |
DEBUG slick.jdbc.StatementInvoker.result - \--------------------+--------------/
[info] - should zipWithIndex *** FAILED *** (ZipJoinTest.scala:68)
[info]   Vector((Colombian,0), (Colombian_Decaf,1), (Espresso,2), (French_Roast,3), (French_Roast_Decaf,4))
[info] was not equal to
[info]   List((Colombian,0), (French_Roast,1), (Espresso,2), (Colombian_Decaf,3), (French_Roast_Decaf,4))
[info] Run completed in 5 seconds, 825 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error]     com.github.dnvriend.ZipJoinTest
[error] (test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 9 s, completed Feb 17, 2016 1:06:56 PM
```

The H2 database, should allow for `testForkedParallel` of tests by SBT and even `ParallelTestExecution` by Scalatest.  However, there would need to be some modification needed to the [TestSpec](src/test/scala/com/github/dnvriend/TestSpec.scala) and [DbExtension](src/main/scala/com/github/dnvriend/DbExtension.scala) so that a process is forked before each test and it didn't share the same actor system.

Thanks again for this Slick test suite!
Aaron
